### PR TITLE
Fix checkbox alignment in headings.

### DIFF
--- a/coords.css
+++ b/coords.css
@@ -89,8 +89,7 @@ section {
 	margin: 0 0 0.5em;
 }
 .menu-heading h3 input {
-	position: absolute;
-	left: 0;
+	float: left;
 }
 .menu-list {
 	width: 20em;


### PR DESCRIPTION
Checkbox currently overlaps the heading when the title gets longer. This should fix that by floating the checkbox instead of absolutely positioning it.

Before and after:
![Before and after](https://cloud.githubusercontent.com/assets/649348/3212117/e649c0ea-ef45-11e3-8751-2141369f10a2.png)
