### PR TITLE
Allow manual coords input for overlaps.

### DIFF
--- a/coords.css
+++ b/coords.css
@@ -36,6 +36,12 @@ section {
 #coords {
 	padding: 0.1em 0.3em;
 }
+#coords2 {
+	padding: 0.1em 0.3em;
+	border: 2px solid #888;
+	font: inherit;
+	width: 4em;
+}
 
 #key input {
 	margin-right: 1.5em;

--- a/coords.js
+++ b/coords.js
@@ -89,6 +89,33 @@ function set_state(el, state) {
 	recomposite_main();
 }
 
+function list_overlaps(r) {
+	var span2 = document.getElementById('coords2'), rekt, inside, input,
+		gathered = { 'checked': [], 'unchecked': [], 'indeterminate': [] };
+
+	span2.innerHTML = r.fx + ',' + r.fy;
+	span2.parentNode.parentNode.style.display = 'block';
+
+	for (category in coords) {
+		for (menu in coords[category]) {
+			for (rekt in coords[category][menu]) {
+				x1y1 = coords[category][menu][rekt];
+				inside = (x1y1[0] <= r.fx) && (r.fx <= x1y1[2]) && (x1y1[1] <= r.fy) && (r.fy <= x1y1[3]);
+				if (inside) {
+					var id = category + menu + rekt;
+					input = document.getElementById(id);
+					gathered[input.dataset.state].push('<a href="#' + id + '" class="overlap">' + menu + ' → ' + rekt + '</a>');
+				}
+			}
+		}
+	}
+	for (var i in gathered) {
+		var el = document.getElementById('overlaps-' + i);
+		el.innerHTML = gathered[i].join('');
+		el.parentNode.style.display = (gathered[i].length === 0) ? 'none' : 'block';
+	}
+}
+
 function format_x1y1(x1, y1, x2, y2) {
 	return '↖ ' + x1 + ',' + y1 + '<br />↘ ' + x2 + ',' + y2;
 }
@@ -152,8 +179,6 @@ function draw() {
 
 	// Click and hover handlers for main canvas
 	var span = document.getElementById('coords');
-	var span2 = document.getElementById('coords2');
-	var overlaps = document.getElementById('overlaps');
 	main.onmousemove = function(e) {
 		var s = '';
 		var r = mouse2coords(e);
@@ -166,30 +191,7 @@ function draw() {
 
 	};
 	main.onclick = function(e) {
-		var r = mouse2coords(e), rekt, inside, input,
-			gathered = { 'checked': [], 'unchecked': [], 'indeterminate': [] };
-
-		span2.innerHTML = r.fx + ',' + r.fy;
-		span2.parentNode.parentNode.style.display = 'block';
-
-		for (category in coords) {
-			for (menu in coords[category]) {
-				for (rekt in coords[category][menu]) {
-					x1y1 = coords[category][menu][rekt];
-					inside = (x1y1[0] <= r.fx) && (r.fx <= x1y1[2]) && (x1y1[1] <= r.fy) && (r.fy <= x1y1[3]);
-					if (inside) {
-						var id = category + menu + rekt;
-						input = document.getElementById(id);
-						gathered[input.dataset.state].push('<a href="#' + id + '" class="overlap">' + menu + ' → ' + rekt + '</a>');
-					}
-				}
-			}
-		}
-		for (var i in gathered) {
-			var el = document.getElementById('overlaps-' + i);
-			el.innerHTML = gathered[i].join('');
-			el.parentNode.style.display = (gathered[i].length === 0) ? 'none' : 'block';
-		}
+		list_overlaps(mouse2coords(e));
 	};
 
 	var b = document.getElementById('b');

--- a/coords.js
+++ b/coords.js
@@ -90,11 +90,13 @@ function set_state(el, state) {
 }
 
 function list_overlaps(r) {
-	var span2 = document.getElementById('coords2'), rekt, inside, input,
+	var span2 = document.getElementById('coords2'),
+		overlaps = document.getElementById('overlaps'),
+		rekt, inside, input,
 		gathered = { 'checked': [], 'unchecked': [], 'indeterminate': [] };
 
-	span2.innerHTML = r.fx + ',' + r.fy;
-	span2.parentNode.parentNode.style.display = 'block';
+	span2.value = r.fx + ',' + r.fy;
+	overlaps.style.display = 'block';
 
 	for (category in coords) {
 		for (menu in coords[category]) {
@@ -126,6 +128,16 @@ function mouse2coords(e) {
 		fx = Math.floor(x / 2),
 		fy = Math.floor(y / 2);
 
+	return { x: x, y: y, fx: fx, fy: fy };
+}
+
+function text2coords(s) {
+	var m = s.match(/^(\d+),(\d+)$/);
+	if (!m) return;
+	var fx = ~~m[1],
+		fy = ~~m[2],
+		x = fx * 2,
+		y = fy * 2;
 	return { x: x, y: y, fx: fx, fy: fy };
 }
 
@@ -192,6 +204,11 @@ function draw() {
 	};
 	main.onclick = function(e) {
 		list_overlaps(mouse2coords(e));
+	};
+	
+	var span2 = document.getElementById('coords2');
+	span2.onchange = function(e) {
+		list_overlaps(text2coords(span2.value));
 	};
 
 	var b = document.getElementById('b');

--- a/index.html
+++ b/index.html
@@ -58,8 +58,8 @@
 <canvas id="main" width="512" height="384"></canvas>
 </div>
 
-<div style="display: none;">
-<p><strong id="coords2"></strong> clicks these buttons:</p>
+<p><input type="text" id="coords2" /> clicks these buttons:</p>
+<div id="overlaps" style="display: none;">
 <p><input type="checkbox" class="noclick"  checked /> I want to click this button<br /><span id="overlaps-checked"></span></p>
 <p><input type="checkbox" class="noclick ind"      /> I want to avoid clicking this button<br /><span id="overlaps-indeterminate"></span></p>
 <p><input type="checkbox" class="noclick"          /> I don’t care if this button is clicked<br /><span id="overlaps-unchecked"></span></p>


### PR DESCRIPTION
Replaced the `span#coords2` with an `input#coords2` and made it trigger the overlap calculation on value change. This way, you can quickly see what buttons are hit by a given coordinate without having to actually aim for that coordinate on the grid.
