### PR TITLE
Update overlaps while typing.

### DIFF
--- a/coords.js
+++ b/coords.js
@@ -216,7 +216,7 @@ function draw() {
 		span2.className = '';
 		span2_errors.style.display = 'none';
 	};
-	span2.onchange = function(e) {
+	var update_overlaps = function() {
 		try {
 			list_overlaps(text2coords(span2.value));
 			span2.className = 'valid';
@@ -228,6 +228,7 @@ function draw() {
 			span2_errors.innerHTML = err;
 		}
 	};
+	span2.onchange = span2.onkeyup = update_overlaps;
 
 	var b = document.getElementById('b');
 	var toc = document.getElementById('toc');


### PR DESCRIPTION
Simply bind the same handler to `onkeyup` as well.

Advantage: you get immediate results.
Disadvantage: it may be annoying if you get errors while typing.

I'll let you decide if you want to merge this or not.
