### PR TITLE
Use DOM ready to initialize stuff.

### DIFF
--- a/state.js
+++ b/state.js
@@ -130,7 +130,7 @@ var State = (function() {
 	return _State;
 })();
 
-window.onload = function() {
+document.addEventListener('DOMContentLoaded', function() {
 	Load.all();
 	try {
 		State.setAllFromUrl();
@@ -150,4 +150,4 @@ window.onload = function() {
 	}
 	draw();
 	recomposite_main();
-}
+});


### PR DESCRIPTION
Initialize sooner in the pipeline, gotta go fast. :stuck_out_tongue: 

Also fixes issue in Chrome where the anchor (e.g. `index.html#bbf`) wouldn't work, presumably because the `bbf` element is not yet in the DOM when the anchor scrolling is done.
