### PR TITLE
State refactor

### DIFF
--- a/coords.js
+++ b/coords.js
@@ -20,9 +20,7 @@ function to_xywh(x1, y1, x2, y2) { return [x1, y1, x2 - x1 + 1, y2 - y1 + 1]; }
 function reset_all(state) {
 	var state = state || 'unchecked';
 	var inputs = document.querySelectorAll('.menu input');
-	for (var i = 0; i < inputs.length; i ++)
-		State.setState(state)(inputs[i].id);
-	State.replaceState();
+	State.setState(state, inputs);
 }
 
 function scale(x, y, w, h) {

--- a/load.js
+++ b/load.js
@@ -85,23 +85,19 @@ var Load = (function() {
 
 			click.onclick = function(e) {
 				var r = mouse2coords(e);
-				list_overlaps(r);
 				coords_click.className = '';
 				coords_click_errors.style.display = 'none';
 
 				State.setCoords(r);
-				State.replaceState();
 			};
 			coords_click.onchange = function(e) {
 				var r;
 				try {
 					r = text2coords(coords_click.value);
-					list_overlaps(r);
 					coords_click.className = 'valid';
 					coords_click_errors.style.display = 'none';
 
 					State.setCoords(r);
-					State.replaceState();
 				}
 				catch (err) {
 					coords_click.className = 'invalid';
@@ -128,7 +124,6 @@ var Load = (function() {
 						State.setCoords(r.map(function(v, i) {
 							return v + deltas[key][i];
 						}));
-						State.replaceState();
 					}
 					catch (e) {
 					}

--- a/state.js
+++ b/state.js
@@ -81,40 +81,52 @@ var State = (function() {
 					bounds[0] + ',' + bounds[1] + ' to ' + bounds[2] + ',' + bounds[3] + '.';
 
 			this.state.coords = coords;
-			list_overlaps(coords);
 		},
-		setState: function(state) {
+		setState: function(state, id) {
 			if (!(state in Box))
 				throw "Invalid state '" + state + "'";
+				
+			if (id) {
+				// Immediate call
+				return this._setState(state, id);
+			} else {
+				// Partial call
+				return function(id) {
+					return this._setState(state, id);
+				}.bind(this);
+			}
+		},
+		_setState: function(state, id) {
+			var el = document.getElementById(id);
+			if (el === null)
+				throw "No element exists with id '" + id + "'";
 
-			return function(id) {
-				var el = document.getElementById(id);
-				if (el === null)
-					throw "No element exists with id '" + id + "'";
+			var currentState = el.dataset.state || 'unchecked';
+			// if (currentState === state)
+			//	throw "Element with id '" + id + "' is already " + state;
 
-				var currentState = el.dataset.state || 'unchecked';
-				// if (currentState === state)
-				//	throw "Element with id '" + id + "' is already " + state;
+			if (currentState in this.state)
+				if (id in this.state[currentState])
+					delete this.state[currentState][id];
 
-				if (currentState in this.state)
-					if (id in this.state[currentState])
-						delete this.state[currentState][id];
+			if (state in this.state)
+				this.state[state][id] = true;
 
-				if (state in this.state)
-					this.state[state][id] = true;
-
-				el.dataset.state = state;
-				el.checked = Box[state].checked;
-				el.indeterminate = Box[state].indeterminate;
-			}.bind(this);
+			el.dataset.state = state;
+			el.checked = Box[state].checked;
+			el.indeterminate = Box[state].indeterminate;
+		},
+		updateState: function(recomposite) {
+			this.replaceState();
+			if (recomposite)
+				recomposite_main();
+			if (this.state.coords.length)
+				list_overlaps(this.state.coords);
 		},
 	};
 	_State.rotateState = (function(_this) { return function(e) {
 		var currentState = this.dataset.state || 'unchecked';
-
-		_this.setState(Box[currentState]['next'])(this.id);
-		_this.replaceState();
-		recomposite_main();
+		_this.setState(Box[currentState]['next'], this.id);
 	}; })(_State);
 	_State.rotateStates = (function(_this) { return function(e) {
 		var currentState = this.dataset.state || 'unchecked',
@@ -125,24 +137,38 @@ var State = (function() {
 		var children = document.querySelectorAll('input[data-parent="' + this.dataset.self + '"][data-grandparent="' + this.dataset.parent + '"]');
 		for (var i = 0; i < children.length; i ++)
 			setState(children[i].id);
-
-		_this.replaceState();
-		recomposite_main();
 	}; })(_State);
+
+	var wrap = function(fn, recomposite, ctxt) {
+		return function() {
+			var result = fn.apply(ctxt || this, arguments);
+			if (typeof result === "function") {
+				return wrap(result, recomposite, ctxt);
+			} else {
+				_State.updateState(recomposite);
+				return result;
+			}
+		};
+	};
+
+	var State = {
+		getUrl:        _State.getUrl.bind(_State),
+		replaceState:  wrap(_State.replaceState, true, _State),
+		setAll:        wrap(_State.setAll, true, _State),
+		setAllFromUrl: wrap(_State.setAllFromUrl, true, _State),
+		setGame:       wrap(_State.setGame, true, _State),
+		setCoords:     wrap(_State.setCoords, false, _State),
+		setState:      wrap(_State.setState, true, _State),
+		rotateState:   wrap(_State.rotateState, true),
+		rotateStates:  wrap(_State.rotateStates, true),
+	};
 	for (var state in Box)
-		_State['set' + state.charAt(0).toUpperCase() + state.slice(1)] = _State.setState(state);
-	return _State;
+		State['set' + state.charAt(0).toUpperCase() + state.slice(1)] = State.setState(state);
+	return State;
 })();
 
 document.addEventListener('DOMContentLoaded', function() {
 	Load.all();
-	try {
-		State.setAllFromUrl();
-	}
-	catch (e) {
-		// TODO display error to user?
-		console.error(e);
-	}
 
 	var inputs = document.querySelectorAll('.menu-list input');
 	for (var i in inputs) {
@@ -152,6 +178,13 @@ document.addEventListener('DOMContentLoaded', function() {
 	for (var i in inputs) {
 		inputs[i].onclick = State.rotateStates;
 	}
+
 	draw();
-	recomposite_main();
+	try {
+		State.setAllFromUrl();
+	}
+	catch (e) {
+		// TODO display error to user?
+		console.error(e);
+	}
 });


### PR DESCRIPTION
Refactored `State` to better handle changes.
- Internal `_State` methods don't do external updates.
- Public `State` methods wrap internal methods to trigger external updates at the end of the call.
- External uses of `State` methods are reduced so each change can be fully handled by one single `State` call, thus only triggering updates once.

This also fixes #31, since now `rotateState` triggers the correct updates.
