### PR TITLE
Fixed moving coordinate with arrow keys.

### DIFF
--- a/load.js
+++ b/load.js
@@ -116,7 +116,7 @@ var Load = (function() {
 			document.body.onkeydown = function(e) {
 				var key = e.keyCode;
 				if (key in deltas) {
-					var r = State.state.coords;
+					var r = State.getCoords();
 					if (r.length === 0)
 						return;
 

--- a/state.js
+++ b/state.js
@@ -16,6 +16,9 @@ var State = (function() {
 		replaceState: function() {
 			window.history.replaceState(this.state, null, this.getUrl() + window.location.hash);
 		},
+		getCoords: function() {
+			return this.state.coords.slice(0);
+		},
 		getUrl: function(state) {
 			if (state === undefined)
 				state = this.state;
@@ -164,6 +167,7 @@ var State = (function() {
 	};
 
 	var State = {
+		getCoords:     _State.getCoords.bind(_State),
 		getUrl:        _State.getUrl.bind(_State),
 		replaceState:  wrap(_State.replaceState, true, _State),
 		setAll:        wrap(_State.setAll, true, _State),


### PR DESCRIPTION
Was broken by 60da622d0df1066f61fafaf8852063f18ee91c48.

The `state` object is now private to `_State` and cannot be externally accessed. Added a getter to retrieve the current coordinates.
