### PR TITLE
More scale fixes.

### DIFF
--- a/coords.css
+++ b/coords.css
@@ -84,14 +84,6 @@ input.noclick {
 .menu-heading .layers {
 	cursor: pointer;
 }
-.menu-heading .layers, .menu-heading .layers canvas, .menu-heading .layers img {
-	width: 128px;
-	height: 96px;
-}
-.then .layers, .then .layers canvas {
-	width: 512px;
-	height: 384px;
-}
 .menu-heading .layers:hover canvas { opacity: 0.75; }
 .menu-heading .layers img { opacity: 0; }
 .menu-heading .layers:hover img { opacity: 1; }

--- a/coords.js
+++ b/coords.js
@@ -8,6 +8,7 @@ var b, current_color, all_inputs, reset_screenshot,
 	zoom_img, main_ctx, varia_ctx, click_ctx,
 	main_scale = 4,
 	mouse_scale = 2,
+	menu_scale = 0.5,
 	level_delim = ' › ',
 	cw = bounds[2] - bounds[0] + 1;
 	ch = bounds[3] - bounds[1] + 1;

--- a/coords.js
+++ b/coords.js
@@ -6,7 +6,8 @@ var palette = [
 
 var b, current_color, all_inputs, reset_screenshot,
 	zoom_img, main_ctx, varia_ctx, click_ctx,
-	main_scale, mouse_scale,
+	main_scale = 4,
+	mouse_scale = 2,
 	level_delim = ' › ',
 	cw = bounds[2] - bounds[0] + 1;
 	ch = bounds[3] - bounds[1] + 1;

--- a/draw.js
+++ b/draw.js
@@ -41,7 +41,7 @@ var Draw = (function() {
 			div2.setAttribute('class', 'menu-list');
 
 			var layers = document.createElement('div');
-			layers.setAttribute('class', 'layers');
+			layers.setAttribute('class', 'layers size-small');
 			div.appendChild(h);
 			div.appendChild(layers);
 
@@ -73,6 +73,7 @@ var Draw = (function() {
 				current_color = 0;
 
 				var c = new_canvas();
+				c.setAttribute('class', 'size-small');
 				var ctx = c.getContext('2d');
 				ctx.globalCompositeOperation = 'dest-over';
 
@@ -85,6 +86,7 @@ var Draw = (function() {
 				img.onerror = this.error.bind(div);
 				img.setAttribute('id', menu_id + '-image');
 				img.setAttribute('src', src);
+				img.setAttribute('class', 'size-small');
 				layers.onclick = zoom.bind(img);
 				layers.appendChild(img);
 

--- a/index.html
+++ b/index.html
@@ -60,12 +60,12 @@
 </p>
 
 
-<div class="layers">
-<canvas id="zoom"  width="1024" height="768"></canvas>
-<canvas id="grid"  width="1024" height="768"></canvas>
-<canvas id="main"  width="1024" height="768"></canvas>
-<canvas id="varia" width="1024" height="768"></canvas>
-<canvas id="click" width="1024" height="768"></canvas>
+<div class="layers size-large">
+<canvas id="zoom"  width="1024" height="768" class="size-large"></canvas>
+<canvas id="grid"  width="1024" height="768" class="size-large"></canvas>
+<canvas id="main"  width="1024" height="768" class="size-large"></canvas>
+<canvas id="varia" width="1024" height="768" class="size-large"></canvas>
+<canvas id="click" width="1024" height="768" class="size-large"></canvas>
 </div>
 
 <p id="reset-screenshot" style="display: none;"><a href="#" onclick="State.setImage(); return false">Reset screenshot</a></p>

--- a/load.js
+++ b/load.js
@@ -40,21 +40,27 @@ var Load = (function() {
 			document.getElementById('example').href = url;
 		},
 
+		styles: function() {
+			var largeSize = scale(mouse_scale, to_xywh(bounds)),
+				smallSize = scale(menu_scale, to_xywh(bounds)),
+				styleSheet = document.createElement('style');
+			styleSheet.innerHTML = '.size-large{'
+				+ 'width:'  + largeSize[2] + 'px;'
+				+ 'height:' + largeSize[3] + 'px;'
+			+ '}'
+			+ '.size-small{'
+				+ 'width:'  + smallSize[2] + 'px;'
+				+ 'height:' + smallSize[3] + 'px;'
+			+ '}';
+			document.head.appendChild(styleSheet);
+		},
 		layers: function() {
-			var canvasSize = scale(main_scale, to_xywh(bounds)),
-				elemSize = scale(mouse_scale, to_xywh(bounds));
-
-			var layers = document.querySelector('.then .layers');
-			layers.style.width = elemSize[2] + 'px';
-			layers.style.height = elemSize[3] + 'px';
-
+			var canvasSize = scale(main_scale, to_xywh(bounds));
 			var canvases = document.querySelectorAll('.then canvas'), canvas;
 			for (var i = 0; i < canvases.length; i ++) {
 				canvas = canvases[i];
 				canvas.width = canvasSize[2];
 				canvas.height = canvasSize[3];
-				canvas.style.width = elemSize[2] + 'px';
-				canvas.style.height = elemSize[3] + 'px';
 			}
 		},
 		grid: function() {
@@ -224,6 +230,7 @@ var Load = (function() {
 			this.unclickables();
 			this.preferences();
 			this.example();
+			this.styles();
 			this.layers();
 
 			this.main_handlers();

--- a/load.js
+++ b/load.js
@@ -40,6 +40,23 @@ var Load = (function() {
 			document.getElementById('example').href = url;
 		},
 
+		layers: function() {
+			var canvasSize = scale(main_scale, to_xywh(bounds)),
+				elemSize = scale(mouse_scale, to_xywh(bounds));
+
+			var layers = document.querySelector('.then .layers');
+			layers.style.width = elemSize[2] + 'px';
+			layers.style.height = elemSize[3] + 'px';
+
+			var canvases = document.querySelectorAll('.then canvas'), canvas;
+			for (var i = 0; i < canvases.length; i ++) {
+				canvas = canvases[i];
+				canvas.width = canvasSize[2];
+				canvas.height = canvasSize[3];
+				canvas.style.width = elemSize[2] + 'px';
+				canvas.style.height = elemSize[3] + 'px';
+			}
+		},
 		grid: function() {
 			var grid = document.getElementById('grid');
 			var grid_ctx = grid.getContext('2d');
@@ -207,6 +224,7 @@ var Load = (function() {
 			this.unclickables();
 			this.preferences();
 			this.example();
+			this.layers();
 
 			this.main_handlers();
 			this.key_handlers();

--- a/onset.js
+++ b/onset.js
@@ -14,10 +14,6 @@ document.addEventListener('DOMContentLoaded', function() {
 		inputs[i].onclick = rotateStates;
 	}
 
-	var main = document.getElementById('main');
-	main_scale = main.width / cw;
-	mouse_scale = main.width / main.offsetWidth;
-
 	all_inputs = document.querySelectorAll('.menu-list input');
 });
 window.onload = function() {

--- a/onset.js
+++ b/onset.js
@@ -15,8 +15,8 @@ document.addEventListener('DOMContentLoaded', function() {
 	}
 
 	var main = document.getElementById('main');
-	main_scale = Math.floor(main.width / cw);
-	mouse_scale = Math.floor(main.width / main.offsetWidth);
+	main_scale = main.width / cw;
+	mouse_scale = main.width / main.offsetWidth;
 
 	all_inputs = document.querySelectorAll('.menu-list input');
 });


### PR DESCRIPTION
I was testing how the tool reacts to bigger screens, and found some issues.
- <strike>Transforming mouse coordinates was wrong. It just happened to work out for Black and Black 2, but no such luck for X.</strike> It turns out it was right after all, reverted. :stuck_out_tongue:
- Scale calculation should not be rounded. For example in X, `main_scale` will be `3.2` (1024 canvas width / 320 screen width), rounding to `3` here causes the rendering to be too small. Proper rounding is already implemented in `scale()`, so no worries about decimals suddenly showing up.
