### PR TITLE
Use globalAlpha instead of opacity for variability.

### DIFF
--- a/coords.css
+++ b/coords.css
@@ -81,9 +81,6 @@ input.noclick {
 	position: absolute;
 	left: 0; top: 0;
 }
-#varia {
-	opacity: 0.5;
-}
 .menu-heading .layers {
 	cursor: pointer;
 }

--- a/coords.js
+++ b/coords.js
@@ -137,7 +137,6 @@ function draw_varia(r) {
 		for (i = 0; i < hit.indeterminate.length; i ++) {
 			rect = hit.indeterminate[i];
 			xywh = coords2main(to_xywh(rect));
-			varia_ctx.clearRect.apply(varia_ctx, xywh);
 			varia_ctx.fillRect.apply(varia_ctx, xywh);
 		}
 	} else if (hit.checked.length) {

--- a/coords.js
+++ b/coords.js
@@ -130,12 +130,14 @@ function draw_varia(r) {
 
 	var i, rect, xywh;
 	varia_ctx.clear();
+	varia_ctx.globalAlpha = 0.4;
 	if (hit.indeterminate.length) {
 		// Hit a button to avoid, show warning
 		varia_ctx.fillStyle = '#f77';
 		for (i = 0; i < hit.indeterminate.length; i ++) {
 			rect = hit.indeterminate[i];
 			xywh = coords2main(to_xywh(rect));
+			varia_ctx.clearRect.apply(varia_ctx, xywh);
 			varia_ctx.fillRect.apply(varia_ctx, xywh);
 		}
 	} else if (hit.checked.length) {


### PR DESCRIPTION
Originally I used CSS `opacity` because I didn't want overlapping "avoid" regions to blend their alpha. However, that same thing can be achieved by clearing first before filling to prevent blending.
