### PR TITLE
Fixed mouse2coords scaling once again.

### DIFF
--- a/coords.js
+++ b/coords.js
@@ -211,7 +211,7 @@ function mouse2coords(e) {
 	var x = (e.offsetX === undefined) ? e.layerX - e.currentTarget.offsetLeft : e.offsetX,
 		y = (e.offsetY === undefined) ? e.layerY - e.currentTarget.offsetTop  : e.offsetY;
 
-	return scale(1 / scales.mouse, [x, y]);
+	return scale(scales.mouse / scales.main, [x, y]);
 }
 
 function text2coords(s) {


### PR DESCRIPTION
One day I'll get this right! :stuck_out_tongue: 

Again, it's not noticeable unless you change the `scales`, e.g. make `scales.main = 3`.
